### PR TITLE
chore: add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+
+node_js:
+  - 8
+  - 10
+  - 12
+
+script:
+  - npm ci
+  - npm test

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/hyperjumptech/universal-update-checker.svg?branch=master)](https://travis-ci.org/hyperjumptech/universal-update-checker)
 [![Build Status](https://dev.azure.com/hyperjumptech/universal-update-checker/_apis/build/status/hyperjumptech.universal-update-checker?branchName=master)](https://dev.azure.com/hyperjumptech/universal-update-checker/_build/latest?definitionId=1&branchName=master)
 
 # Universal Update Checker


### PR DESCRIPTION
By default, travis with node_js script will run `npm test` command. But, in this configuration, I'm making a change by adding `npm ci` command in the script. This is for consistency between travis and azure pipeline.