### PR TITLE
Flatten the published directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ examples/RNUpdateCheckerExample/ios/Pods/
 
 # production
 /build
+/dist
 
 # misc
 /.DS_Store

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 /examples
+src/**/*.test.js

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,11 @@
 module.exports = {
-  presets: ["module:metro-react-native-babel-preset"]
+  presets: ["module:metro-react-native-babel-preset"],
+  env: {
+    production: {
+      ignore: [
+        "**/*.test.js"
+      ],
+      sourceMaps: true
+    }
+  }
 };

--- a/package.json
+++ b/package.json
@@ -1,15 +1,13 @@
 {
   "name": "@hyperjumptech/universal-update-checker",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "React component to check if there is a new version of the app",
-  "main": "src/index.js",
-  "files": [
-    "src"
-  ],
+  "main": "build/index.js",
+  "files": ["build"],
   "scripts": {
-    "build": "rm -rf build && publish-flat -f src -o build && cd build && npm pack",
-    "test": "jest src",
-    "develop": "cd src && sync-glob --watch . ../examples/RNUpdateCheckerExample/node_modules/universal-update-checker"
+    "build-module": "rm -rf build && rm -rf dist && NODE_ENV=production babel src --out-dir build && publish-flat -f build -o dist",
+    "publish-module": "npm run build-module && cd dist && npm publish",
+    "test": "jest src"
   },
   "repository": {
     "type": "git",
@@ -30,7 +28,12 @@
   },
   "jest": {
     "preset": "react-native",
-    "testEnvironment": "jsdom"
+    "testEnvironment": "jsdom",
+    "testPathIgnorePatterns": [
+      "<rootDir>/build/", 
+      "<rootDir>/dist/", 
+      "<rootDir>/node_modules/"
+    ]
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",


### PR DESCRIPTION
# Problem

Currently, user of this library needs to include `src` when importing the default local and remote functions as follows: 

```javascript
import {
  getUpdateStatus,
  getVersionsFromFirebase,
  getLocalVersion,
} from '@hyperjumptech/universal-update-checker/src/default-local-remote';
```

It would've been much better if user can import them without `src`

# Solution

This PR solves this problem by flattening the published directory using `publish-flat` library.

## Caveat

To publish to npm registry, maintainer should use `npm run publish-module` command instead of `npm publish`